### PR TITLE
Fix selection of initial value in wxTextEntryDialog

### DIFF
--- a/src/generic/textdlgg.cpp
+++ b/src/generic/textdlgg.cpp
@@ -126,7 +126,6 @@ bool wxTextEntryDialog::Create(wxWindow *parent,
     if ( style & wxCENTRE )
         Centre( wxBOTH );
 
-    m_textctrl->SelectAll();
     m_textctrl->SetFocus();
 
     wxEndBusyCursor();
@@ -139,6 +138,7 @@ bool wxTextEntryDialog::TransferDataToWindow()
     if ( m_textctrl )
     {
         m_textctrl->SetValue(m_value);
+        m_textctrl->SelectAll();
     }
 
     return wxDialog::TransferDataToWindow();


### PR DESCRIPTION
The initial value in wxTextEntryDialog was not preselected as it was likely intended by the code because the SelectAll-Method of the wxTextCtrl was called before the value was set. Now the SelectAll-Method is called after setting the value in wxTextEntryDialog::TransferDataToWindow.

Please let me know if there should be anything else done for this change or if the old behaviour was intended.
